### PR TITLE
Corrected square() when passed a single number

### DIFF
--- a/src/primitives2d.js
+++ b/src/primitives2d.js
@@ -8,7 +8,7 @@ export function square () {
   let a = arguments
   let p = a[0]
 
-  if (p && !p.size) v = [p, p]
+  if (p && Number.isFinite(p)) v = [p, p]
   if (p && p.length) v = a[0], p = a[1]
   if (p && p.size && p.size.length) v = p.size
 

--- a/src/primitives2d.test.js
+++ b/src/primitives2d.test.js
@@ -87,10 +87,10 @@ test('square (default size, centered)', t => {
   const obs = square({center: true})
 
   const expSides = [
-    [[0, 1], [0, 0]],
-    [[0, 0], [1, 0]],
-    [[1, 0], [1, 1]],
-    [[1, 1], [0, 1]]
+    [[-0.5, 0.5], [-0.5, -0.5]],
+    [[-0.5, -0.5], [0.5, -0.5]],
+    [[0.5, -0.5], [0.5, 0.5]],
+    [[0.5, 0.5], [-0.5, 0.5]]
   ]
 
   t.deepEqual(obs.sides.length, 4)


### PR DESCRIPTION
And the test case too.