### PR TITLE
Moved hue2rgb() externally to allow strict compilers (Safari) to work

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -256,15 +256,6 @@ export function hsl2rgb (h, s, l) {
   if (s == 0) {
     r = g = b = l // achromatic
   } else {
-    function hue2rgb (p, q, t) {
-      if (t < 0) t += 1
-      if (t > 1) t -= 1
-      if (t < 1 / 6) return p + (q - p) * 6 * t
-      if (t < 1 / 2) return q
-      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
-      return p
-    }
-
     var q = l < 0.5 ? l * (1 + s) : l + s - l * s
     var p = 2 * l - q
     r = hue2rgb(p, q, h + 1 / 3)
@@ -273,6 +264,15 @@ export function hsl2rgb (h, s, l) {
   }
 
   return [r, g, b]
+}
+
+function hue2rgb (p, q, t) {
+  if (t < 0) t += 1
+  if (t > 1) t -= 1
+  if (t < 1 / 6) return p + (q - p) * 6 * t
+  if (t < 1 / 2) return q
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+  return p
 }
 
 /**


### PR DESCRIPTION
This small change allows Safari 9.1 to work with the latest builds.